### PR TITLE
Split sote goals and regular goals

### DIFF
--- a/docs/_challenges/all_katanas.md
+++ b/docs/_challenges/all_katanas.md
@@ -5,21 +5,22 @@ show_in_list: true
 show_in_menu: true
 title: All Katanas
 goals:
- - Dragon-Hunter's Great Katana
  - Dragonscale Blade
  - Elden Beast
- - Great Katana
  - Hand of Malenia
  - Meteoric Ore Blade
  - Moonveil
  - Nagakiba
- - Rakshasa's Great Katana
  - Rivers of Blood
  - Serpentbone Blade
- - Star-lined Sword
- - Sword of Night
  - Uchigatana
  - Wakizashi
+goals_sote:
+ - Dragon-Hunter's Great Katana
+ - Great Katana
+ - Rakshasa's Great Katana
+ - Star-lined Sword
+ - Sword of Night
 ---
 
 ## Overview

--- a/docs/_challenges/red_bear_dragon_hunt.md
+++ b/docs/_challenges/red_bear_dragon_hunt.md
@@ -7,9 +7,6 @@ title: Red Bear Dragon Hunt
 goals:
  - Ancient Dragon Florissax
  - Ancient Dragon Lansseax
- - Ancient Dragon Senessax
- - Ancient Dragon-Man
- - Bayle The Dread
  - Borealis, the Freezing Fog
  - Decaying Ekzykes
  - Draconic Tree Sentinel
@@ -19,17 +16,22 @@ goals:
  - Farum Azula Dragon
  - Flying Dragon Agheel
  - Flying Dragon Greyll
- - Ghostflame Dragon
  - Glintstone Dragon
  - Glintstone Dragon Adula
  - Glintstone Dragon Smarag
  - Godrick the Grafted
  - Great Wyrm Theodorix
- - Great Wyrm Theodorix
- - Jagged Peak Drake
  - Lichdragon Fortissax
  - Magma Wyrm
  - Magma Wyrm Makar
+goals_sote:
+ - Ancient Dragon-Man
+ - Ancient Dragon Senessax
+ - Bayle The Dread
+ - Ghostflame Dragon
+ - Jagged Peak Drake
+ - Magma Wyrm
+
 ---
 
 ## Overview

--- a/docs/_challenges/shadow_of_the_black_knives.md
+++ b/docs/_challenges/shadow_of_the_black_knives.md
@@ -5,7 +5,6 @@ show_in_list: true
 show_in_menu: false
 title: Shadow of the Black Knives
 goals:
-
  - Anastasia, Tarnished-Eater
  - Bloody Finger Nerijus
  - Bloody Finger Okina
@@ -49,7 +48,7 @@ As a Black Knife Assassin, finish what was started on The Night of the Black Kni
 - May only equip [Daggers](https://eldenring.wiki.fextralife.com/Daggers){:target="_blank"} after the Chapel of Anticipation
 - May only wear the [Black Knife Set](https://eldenring.wiki.fextralife.com/Black+Knife+Set){:target="_blank"} after the Chapel of Anticipation
 - No incantations or sorceries
-- Only Standard Spirit Ashes and [Black Knife Tiche](https://eldenring.wiki.fextralife.com/Black+Knife+Tiche+Ashes){:target="_blank"} maybe be summoned
+- Only Standard Spirit Ashes and [Black Knife Tiche](https://eldenring.wiki.fextralife.com/Black+Knife+Tiche+Ashes){:target="_blank"} may be summoned
 - No NPC Summons except for Radahn Festival
 
 ## Setup

--- a/docs/_layouts/challenge.html
+++ b/docs/_layouts/challenge.html
@@ -8,9 +8,8 @@ layout: base
 
 {{ content }}
 
-<div class="challenge-goal-heading">
-    <h2>Goals</h2>
-</div>
+<h2>Goals</h2>
+<h3>Base Game</h3>
 <ul class="challenge-goal-list">
     {% for item in page.goals %}
     <li class="challenge-goal">
@@ -20,4 +19,22 @@ layout: base
         <a href="https://eldenring.wiki.fextralife.com/{{item}}" target="_blank">{{item}}</a>
     </li>
     {% endfor %}
+    {%if page.goals == null %}
+        <p>Not applicable</p>
+    {% endif %}
+</ul>
+
+<h3>Shadow of the Erdtree</h3>
+<ul class="challenge-goal-list">
+    {% for item in page.goals_sote %}
+        <li class="challenge-goal">
+            <label class="challenge-goal-checkbox">
+                <input type="checkbox" name="{{ page.title }} | {{ item }}" />
+            </label>
+            <a href="https://eldenring.wiki.fextralife.com/{{item}}" target="_blank">{{item}}</a>
+        </li>
+    {% endfor %}
+    {%if page.goals_sote == null %}
+        <p>Not applicable</p>
+    {% endif %}
 </ul>


### PR DESCRIPTION
This PR adds a separate object for splitting SOTE goals and base game goals. This will allow people to run challenges and easily ignore a SOTE goals on previous versions of the game or if they don't have the DLC